### PR TITLE
fix: nullable session types for listSessions calls

### DIFF
--- a/src/query-etherpad.ts
+++ b/src/query-etherpad.ts
@@ -330,12 +330,12 @@ export default class Etherpad {
 
   async listSessionsOfGroup(qs: Group, throwOnEtherpadError = true) {
     this._checkVersion(`1.0.0`)
-    return this._query<{[sessionID: string]: AuthorSession} | null>(`listSessionsOfGroup`, qs, throwOnEtherpadError)
+    return this._query<{[sessionID: string]: AuthorSession | null} | null>(`listSessionsOfGroup`, qs, throwOnEtherpadError)
   }
 
   async listSessionsOfAuthor(qs: Author, throwOnEtherpadError = true) {
     this._checkVersion(`1.0.0`)
-    return this._query<{[sessionID: string]: AuthorSession} | null>(`listSessionsOfAuthor`, qs, throwOnEtherpadError)
+    return this._query<{[sessionID: string]: AuthorSession | null} | null>(`listSessionsOfAuthor`, qs, throwOnEtherpadError)
   }
 
   ////////


### PR DESCRIPTION
From a real production DB edge case, the return value of the listSessions calls may map a session ID to a null session.